### PR TITLE
Fix compilation for IntelliJ 2026.2 (JCEF module split)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "no.hvl.tk"
-version = "2.5.3"
+version = "2.5.4"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_25
@@ -25,9 +25,11 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        intellijIdea("2026.1")
+        intellijIdea("2026.2")
         bundledPlugin("com.intellij.java")
         bundledModule("intellij.java.debugger.impl")
+        bundledModule("intellij.platform.ui.jcef")
+        bundledModule("intellij.libraries.jcef")
     }
 
     implementation(libs.plantuml)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,7 @@
        on how to target different products -->
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.java</depends>
+  <depends>com.intellij.modules.jcef</depends>
 
   <projectListeners>
     <listener class="no.hvl.tk.visual.debugger.DebugProcessListener"


### PR DESCRIPTION
## Summary

Upgrading to `intellijIdea("2026.2")` broke compilation because JCEF (`JBCefBrowser` / `org.cef.*`) was extracted into separate bundled modules in 2026.2.

## Changes

- **build.gradle.kts**: add `bundledModule("intellij.platform.ui.jcef")` (provides `com.intellij.ui.jcef.*`) and `bundledModule("intellij.libraries.jcef")` (provides the raw `org.cef.*` classes used by `SimpleDownloadHandler`).
- **plugin.xml**: declare `<depends>com.intellij.modules.jcef</depends>`.
- Bump plugin version `2.5.3` → `2.5.4`.

## Verification

`./gradlew check` (compile + Spotless + Error Prone + tests) passes.
